### PR TITLE
Generate concrete behavior registrations

### DIFF
--- a/src/Immediate.Handlers.Generators/ImmediateHandlersGenerator.cs
+++ b/src/Immediate.Handlers.Generators/ImmediateHandlersGenerator.cs
@@ -116,10 +116,28 @@ public sealed partial class ImmediateHandlersGenerator : IIncrementalGenerator
 				Namespace = @namespace,
 				Version = ThisAssembly.InformationalVersion,
 
-				Behaviors = behaviors
-					.Concat(handlers.SelectMany(h => h.OverrideBehaviors ?? []))
-					.WhereNotNull()
-					.Select(b => new { b.RegistrationType })
+				Behaviors = handlers
+					.SelectMany(h =>
+					{
+						var responseType = h.ResponseType ?? new GenericType
+						{
+							Name = "global::System.ValueTuple",
+							Implements = default,
+						};
+						var behaviorSource = h.OverrideBehaviors?.AsEnumerable()
+							?? behaviors.AsEnumerable();
+
+						return BuildPipeline(
+							h.RequestType,
+							responseType,
+							behaviorSource.Where(b => b is null || b.IsStreaming == h.IsStreaming)
+						)
+							.WhereNotNull()
+							.Select(b => new
+							{
+								TypeName = GetBehaviorTypeName(b, h.RequestType.Name, responseType.Name),
+							});
+					})
 					.Distinct(),
 
 				HandlersByTag = handlers
@@ -243,13 +261,7 @@ public sealed partial class ImmediateHandlersGenerator : IIncrementalGenerator
 			.WhereNotNull()
 			.Select(b => new RenderBehavior
 			{
-				TypeName = (b.RequestType.ExactType, b.ResponseType.ExactType) switch
-				{
-					(null, null) => $"{b.NonGenericTypeName}<{requestName}, {responseName}>",
-					({ }, null) => $"{b.NonGenericTypeName}<{responseName}>",
-					(null, { }) => $"{b.NonGenericTypeName}<{requestName}>",
-					({ }, { }) => b.NonGenericTypeName,
-				},
+				TypeName = GetBehaviorTypeName(b, requestName, responseName),
 
 				VariableName = b.Name[0..1].ToLowerInvariant()
 					+ b.Name[1..]
@@ -260,6 +272,18 @@ public sealed partial class ImmediateHandlersGenerator : IIncrementalGenerator
 
 		return renderBehaviors;
 	}
+
+	private static string GetBehaviorTypeName(
+		Behavior behavior,
+		string requestName,
+		string responseName
+	) => (behavior.RequestType.ExactType, behavior.ResponseType.ExactType) switch
+	{
+		(null, null) => $"{behavior.NonGenericTypeName}<{requestName}, {responseName}>",
+		({ }, null) => $"{behavior.NonGenericTypeName}<{responseName}>",
+		(null, { }) => $"{behavior.NonGenericTypeName}<{requestName}>",
+		({ }, { }) => behavior.NonGenericTypeName,
+	};
 
 	private static Template GetTemplate(string name)
 	{

--- a/src/Immediate.Handlers.Generators/Models.cs
+++ b/src/Immediate.Handlers.Generators/Models.cs
@@ -13,7 +13,6 @@ public sealed record AssemblyDefaults
 [ExcludeFromCodeCoverage]
 public sealed record Behavior
 {
-	public required string RegistrationType { get; init; }
 	public required string NonGenericTypeName { get; init; }
 	public required string Name { get; init; }
 	public required ConstraintInfo RequestType { get; init; }

--- a/src/Immediate.Handlers.Generators/Templates/ServiceCollectionExtensions.sbntxt
+++ b/src/Immediate.Handlers.Generators/Templates/ServiceCollectionExtensions.sbntxt
@@ -15,7 +15,7 @@ public static class HandlerServiceCollectionExtensions
 	)
 	{
 		{{~ for b in behaviors ~}}
-		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddTransient(services, typeof({{ b.registration_type }}));
+		global::Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddTransient(services, typeof({{ b.type_name }}));
 		{{~ end ~}}
 		
 		return services;

--- a/src/Immediate.Handlers.Generators/TransformBehaviors.cs
+++ b/src/Immediate.Handlers.Generators/TransformBehaviors.cs
@@ -62,12 +62,6 @@ internal static class TransformBehaviors
 
 				cancellationToken.ThrowIfCancellationRequested();
 
-				// global::Dummy.LoggingBehavior<,> or global::Dummy.LoggingBehavior<> or global::Dummy.LoggingBehavior
-				// for: `services.AddScoped(typeof(..));`
-				var typeName = symbol.ToDisplayString(DisplayNameFormatters.FullyQualifiedWithNullableFormat);
-
-				cancellationToken.ThrowIfCancellationRequested();
-
 				// global::Dummy.LoggingBehavior
 				// for: private readonly global::Dummy.LoggingBehavior
 				var constructorType = symbol.OriginalDefinition.ToDisplayString(DisplayNameFormatters.NonGenericFqdnFormat);
@@ -79,7 +73,6 @@ internal static class TransformBehaviors
 				cancellationToken.ThrowIfCancellationRequested();
 				return new Behavior
 				{
-					RegistrationType = typeName,
 					NonGenericTypeName = constructorType,
 					RequestType = constraintInfo.RequestConstraints.ToEquatableConstraint(),
 					ResponseType = constraintInfo.ResponseConstraints.ToEquatableConstraint(),

--- a/tests/Immediate.Handlers.Tests/GeneratorTests/AddHandlersTests.cs
+++ b/tests/Immediate.Handlers.Tests/GeneratorTests/AddHandlersTests.cs
@@ -2,6 +2,59 @@ namespace Immediate.Handlers.Tests.GeneratorTests;
 
 public sealed class AddHandlersTests
 {
+	[Fact]
+	public void BehaviorsUseConcreteRegistrations()
+	{
+		var result = GeneratorTestHelper.RunGenerator(
+			"""
+			using System.Threading;
+			using System.Threading.Tasks;
+			using Immediate.Handlers.Shared;
+
+			[assembly: Behaviors(typeof(LoggingBehavior<,>))]
+
+			public sealed class LoggingBehavior<TRequest, TResponse> : Behavior<TRequest, TResponse>
+			{
+				public override ValueTask<TResponse> HandleAsync(TRequest request, CancellationToken cancellationToken)
+					=> Next(request, cancellationToken);
+			}
+
+			[Handler]
+			public static partial class FirstHandler
+			{
+				public sealed record Query;
+				private static ValueTask<int> HandleAsync(Query query, CancellationToken cancellationToken)
+					=> ValueTask.FromResult(1);
+			}
+
+			[Handler]
+			public static partial class SecondHandler
+			{
+				public sealed record Command;
+				private static ValueTask HandleAsync(Command command, CancellationToken cancellationToken)
+					=> ValueTask.CompletedTask;
+			}
+			"""
+		);
+
+		var source = result.GeneratedTrees
+			.Single(t => t.FilePath.EndsWith("IH.ServiceCollectionExtensions.g.cs", StringComparison.Ordinal))
+			.GetText(TestContext.Current.CancellationToken)
+			.ToString();
+
+		Assert.Contains(
+			"typeof(global::LoggingBehavior<global::FirstHandler.Query, int>)",
+			source,
+			StringComparison.Ordinal
+		);
+		Assert.Contains(
+			"typeof(global::LoggingBehavior<global::SecondHandler.Command, global::System.ValueTuple>)",
+			source,
+			StringComparison.Ordinal
+		);
+		Assert.DoesNotContain("typeof(global::LoggingBehavior<,>)", source, StringComparison.Ordinal);
+	}
+
 	[Theory]
 	[MemberData(nameof(Frameworks))]
 	public async Task ValidAddHandlerssMethod(string framework)


### PR DESCRIPTION
### Motivation
- Avoid emitting open-generic DI registrations for behaviors so runtime DI (and Native AOT) won't try to construct open-generic services for value-type responses. 
- Ensure the same closed generic behavior types used when generating handler pipelines are registered in the service-collection extension.

### Description
- Build concrete, per-handler behavior registrations by evaluating each handler's `RequestType`/`ResponseType` and applicable behaviors instead of emitting an open generic `typeof(Behavior<,>)` registration. 
- Centralize behavior type formatting with a new helper `GetBehaviorTypeName` and reuse it for both handler generation and service registrations. 
- Update the service-collection template `ServiceCollectionExtensions.sbntxt` to register `typeof({{ b.type_name }})` (closed type) instead of an open generic. 
- Remove the unused `RegistrationType` model property and add a new unit test `BehaviorsUseConcreteRegistrations` in `tests/Immediate.Handlers.Tests/GeneratorTests/AddHandlersTests.cs` that asserts concrete registrations are emitted for explicit and implicit (`ValueTuple`) responses.

### Testing
- Ran `dotnet test tests/Immediate.Handlers.Tests/Immediate.Handlers.Tests.csproj -f net10.0 --no-restore` and observed `151` tests passed. 
- Ran the solution test run (`dotnet test Immediate.Handlers.slnx`) where the tests executed for .NET 10 and .NET 11 passed (combined run covered `356` tests for available runtimes), while the overall command reported unavailable runtimes for .NET 8/.NET 9 in the environment. 
- Ran `git diff --check` to verify no whitespace/merge issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a752ce696e883219564612822e2ea57)